### PR TITLE
Ignore additional Weglot namespace from scoping. Bump to 1.0.1

### DIFF
--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Weglot Companion
  * Plugin URI:        https://github.com/moderntribe/weglot-companion
  * Description:       Weglot Companion WordPress Plugin
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -149,6 +149,7 @@ return [
 	'exclude-namespaces'      => [
 		'Tribe\Weglot',
 		'WeglotWP',
+		'Weglot',
 		// 'Acme\Foo'                     // The Acme\Foo namespace (and sub-namespaces)
 		// '~^PHPUnit\\\\Framework$~',    // The whole namespace PHPUnit\Framework (but not sub-namespaces)
 		// '~^$~',                        // The root namespace only

--- a/src/Core.php
+++ b/src/Core.php
@@ -23,7 +23,7 @@ final class Core {
 
 	public const    PLUGIN_FILE        = 'plugin.file';
 	public const    VERSION_DEFINITION = 'plugin.version';
-	public const    VERSION            = '1.0.0';
+	public const    VERSION            = '1.0.1';
 	public const    RESOURCES_PATH     = 'plugin.resources_path';
 	public const    RESOURCES_URI      = 'plugin.resources_uri';
 	public const    DIST_DIR_PATH      = 'plugin.dist_dir_path';


### PR DESCRIPTION
- bugfix to not scope additional Weglot namespaces