### PR TITLE
Bugfix: use the correct number of arguments for the filter

### DIFF
--- a/src/Translate/Translate_Subscriber.php
+++ b/src/Translate/Translate_Subscriber.php
@@ -42,7 +42,7 @@ class Translate_Subscriber extends Abstract_Subscriber {
 
 				return $content;
 			}
-		}, 10, 1 );
+		}, 10, 3 );
 	}
 
 }


### PR DESCRIPTION
- Wrong number of arguments on the `add_filter()`