### PR TITLE
BUGFIX: use unique tribe libs meta map filter

### DIFF
--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Weglot Companion
  * Plugin URI:        https://github.com/moderntribe/weglot-companion
  * Description:       Weglot Companion WordPress Plugin
- * Version:           1.2.1
+ * Version:           1.2.2
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -138,8 +138,10 @@ return [
 				return $content;
 			}
 
+			$filter = uniqid( 'tribe_weglot_get_meta_repo_' );
+
 			// Ensure our meta repo WP filter is unique from other tribe-libs instances
-			return str_replace( 'tribe_get_meta_repo', 'tribe_get_meta_repo_scoped', $content );
+			return str_replace( 'tribe_get_meta_repo', $filter, $content );
 		},
 		static function ( string $filePath, string $prefix, string $content ): string {
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -24,7 +24,7 @@ final class Core {
 
 	public const    PLUGIN_FILE        = 'plugin.file';
 	public const    VERSION_DEFINITION = 'plugin.version';
-	public const    VERSION            = '1.2.1';
+	public const    VERSION            = '1.2.2';
 	public const    RESOURCES_PATH     = 'plugin.resources_path';
 	public const    RESOURCES_URI      = 'plugin.resources_uri';
 	public const    DIST_DIR_PATH      = 'plugin.dist_dir_path';


### PR DESCRIPTION
- Ensure each release zip is using a unique tribe libs meta map filter, so the meta map repository instances are unique to this plugin and don't conflict with projects or other plugins using the plugin starter. 