### PR TITLE
Fix invalid mount config

### DIFF
--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -11,7 +11,7 @@ x-nginx: &nginx
     image: nginx:stable-alpine
     working_dir: /application
     volumes:
-        - ../..:/application/www:ro,nocopy,cached
+        - ../..:/application/www:ro
         - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
         - ./nginx/fastcgi.conf:/etc/nginx/fastcgi_params
 
@@ -30,8 +30,8 @@ x-php: &php
     working_dir: /application
     user: "${SQ1_UID:-1000}:${SQ1_GID:-1000}"
     volumes:
-        - ../..:/application/www/public/wp-content/plugins/weglot-companion:rw,nocopy,cached
-        - ../..:/application/www:rw,nocopy,cached
+        - ../..:/application/www/public/wp-content/plugins/weglot-companion
+        - ../..:/application/www
         - ./php/php-ini-overrides.ini:/usr/local/etc/php/conf.d/zz-overrides.ini
         - ./php/msmtp.conf:/etc/msmtprc:ro
         - ./wp-cli.yml:/application/wp-cli.yml


### PR DESCRIPTION
```
Error response from daemon: invalid volume specification: ...wp-content/plugins/plugin-starter:rw,nocopy': invalid mount config for type "bind": field VolumeOptions must not be specified
```