### PR TITLE
Bugfix: crash during wp cli commands

### DIFF
--- a/core.php
+++ b/core.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Tribe Weglot Companion
  * Plugin URI:        https://github.com/moderntribe/weglot-companion
  * Description:       Weglot Companion WordPress Plugin
- * Version:           1.3.0
+ * Version:           1.3.1
  * Requires PHP:      7.4
  * Author:            Modern Tribe
  * Author URI:        https://tri.be

--- a/dev/tests/tests/integration/Tribe/Cache/PostIdentifierTest.php
+++ b/dev/tests/tests/integration/Tribe/Cache/PostIdentifierTest.php
@@ -66,4 +66,12 @@ final class PostIdentifierTest extends Test_Case {
 		$this->assertSame( $post_id, $post_identifier->get_current_post_id() );
 	}
 
+	public function test_it_does_not_find_a_post_when_missing_http_host(): void {
+		unset( $_SERVER['HTTP_HOST'] );
+
+		$post_identifier = $this->container->get( Post_Identifier::class );
+
+		$this->assertSame( 0, $post_identifier->get_current_post_id() );
+	}
+
 }

--- a/src/Cache/Post_Identifier.php
+++ b/src/Cache/Post_Identifier.php
@@ -2,6 +2,7 @@
 
 namespace Tribe\Weglot\Cache;
 
+use League\Uri\Exceptions\SyntaxError;
 use Tribe\Weglot\Uri\Uri_Factory;
 
 class Post_Identifier {
@@ -16,8 +17,6 @@ class Post_Identifier {
 	 * Detect the currently viewed post_id.
 	 *
 	 * @param array $server The PHP $_SERVER global or an array that matches that structure.
-	 *
-	 * @return int
 	 */
 	public function get_current_post_id( array $server = [] ): int {
 		global $post;
@@ -28,7 +27,11 @@ class Post_Identifier {
 			return $post->ID;
 		}
 
-		$uri = $this->uri_factory->create_from_server( $server );
+		try {
+			$uri = $this->uri_factory->create_from_server( $server );
+		} catch ( SyntaxError $e ) {
+			return 0;
+		}
 
 		return url_to_postid( $uri->toString() );
 	}

--- a/src/Cache/Weglot_Cache_Manager.php
+++ b/src/Cache/Weglot_Cache_Manager.php
@@ -39,8 +39,6 @@ class Weglot_Cache_Manager {
 	 * @filter weglot_html_treat_page
 	 *
 	 * @param string $translated_content
-	 *
-	 * @return string
 	 */
 	public function cache_translation( string $translated_content ): string {
 		if ( $this->skip_cache() || empty( $translated_content ) ) {
@@ -63,8 +61,6 @@ class Weglot_Cache_Manager {
 	 * @filter weglot_active_translation_before_treat_page
 	 *
 	 * @param  bool  $active_translation
-	 *
-	 * @return bool
 	 */
 	public function render_cached_translation( bool $active_translation ): bool {
 		if ( $this->skip_cache() ) {
@@ -104,8 +100,6 @@ class Weglot_Cache_Manager {
 	/**
 	 * Whether we should skip caching or displaying cached data for a
 	 * translated post.
-	 *
-	 * @return bool
 	 */
 	protected function skip_cache(): bool {
 		if ( ! $this->post_id() ) {

--- a/src/Core.php
+++ b/src/Core.php
@@ -24,7 +24,7 @@ final class Core {
 
 	public const    PLUGIN_FILE        = 'plugin.file';
 	public const    VERSION_DEFINITION = 'plugin.version';
-	public const    VERSION            = '1.3.0';
+	public const    VERSION            = '1.3.1';
 	public const    RESOURCES_PATH     = 'plugin.resources_path';
 	public const    RESOURCES_URI      = 'plugin.resources_uri';
 	public const    DIST_DIR_PATH      = 'plugin.dist_dir_path';

--- a/src/Translate/Translate_Definer.php
+++ b/src/Translate/Translate_Definer.php
@@ -14,6 +14,9 @@ use WeglotWP\Services\Translate_Service_Weglot;
 
 class Translate_Definer implements Definer_Interface {
 
+	/**
+	 * @return mixed[]
+	 */
 	public function define(): array {
 		return [
 			Parser::class                     => static fn () => weglot_get_service( 'Parser_Service_Weglot' )->get_parser(),

--- a/src/Uri/Uri_Factory.php
+++ b/src/Uri/Uri_Factory.php
@@ -11,8 +11,6 @@ class Uri_Factory {
 	 * Create a Uri instance.
 	 *
 	 * @param array $server The PHP $_SERVER global, or something similar.
-	 *
-	 * @return \League\Uri\Contracts\UriInterface
 	 */
 	public function create_from_server( array $server = [] ): UriInterface {
 		if ( empty( $server ) ) {


### PR DESCRIPTION
- Fixes `PHP Fatal error:  Uncaught Tribe\Weglot_Scoped\League\Uri\Exceptions\SyntaxError: The host could not be detected in /xxx/wp-content/plugins/weglot-companion/vendor/league/uri/src/Uri.php:616` when running some WP CLI commands